### PR TITLE
Link for governance to the givernance repository

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 # Strimzi Community Code of Conduct
 
-Strimzi project follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+Strimzi Community Code of Conduct is defined in the [governance repository](https://github.com/strimzi/governance/blob/master/CODE_OF_CONDUCT.md).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,3 +1,3 @@
 # Strimzi Governance
 
-This repository follows the Strimzi Governance policy as described in [the `GOVERNANCE.md` document in the main Strimzi repository](https://github.com/strimzi/strimzi-kafka-operator/blob/master/GOVERNANCE.md).
+Strimzi Governance is defined in the [governance repository](https://github.com/strimzi/governance/blob/master/GOVERNANCE.md).

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,3 @@
+# Strimzi Maintainers list
+
+Strimzi Maintainers list is defined in the [governance repository](https://github.com/strimzi/governance/blob/master/MAINTAINERS).


### PR DESCRIPTION
This PR implements the proposal https://github.com/strimzi/strimzi-kafka-operator/blob/master/design/github-repository-restructuring.md. After creating the new repo containing the governance files, we should change the files in this repo and just have them to link to the governance repository.